### PR TITLE
Some improvements

### DIFF
--- a/src/main/java/pro/evanwright/saphira/DatabaseClient.java
+++ b/src/main/java/pro/evanwright/saphira/DatabaseClient.java
@@ -27,6 +27,17 @@ public abstract class DatabaseClient {
      * Executes a SQL DML statement and returns the number of rows that were altered.
      *
      * @param sqlStatement The SQL statement to execute
+     * @return The number of rows altered
+     * @throws UncheckedSQLException If a {@link SQLException} occurs
+     */
+    public int update(@NotNull String sqlStatement) throws UncheckedSQLException {
+        return update(sqlStatement, null);
+    }
+
+    /**
+     * Executes a SQL DML statement and returns the number of rows that were altered.
+     *
+     * @param sqlStatement The SQL statement to execute
      * @param psPreparer   The preparer that prepares the SQL statement
      * @return The number of rows altered
      * @throws UncheckedSQLException If a {@link SQLException} occurs
@@ -45,10 +56,32 @@ public abstract class DatabaseClient {
      * Does the same thing as {@link DatabaseClient#update(String, SQLConsumer)} except
      * does everything asynchronously and returns a {@link CompletableFuture}.
      *
+     * @see DatabaseClient#update(String)
+     */
+    public CompletableFuture<Integer> updateAsync(@NotNull String sqlStatement) throws UncheckedSQLException {
+        return updateAsync(sqlStatement, null);
+    }
+
+    /**
+     * Does the same thing as {@link DatabaseClient#update(String, SQLConsumer)} except
+     * does everything asynchronously and returns a {@link CompletableFuture}.
+     *
      * @see DatabaseClient#update(String, SQLConsumer)
      */
-    public CompletableFuture<Integer> updateAsync(@NotNull String sqlStatement, @NotNull SQLConsumer<PreparedStatement> psPreparer) throws UncheckedSQLException {
+    public CompletableFuture<Integer> updateAsync(@NotNull String sqlStatement, @Nullable SQLConsumer<PreparedStatement> psPreparer) throws UncheckedSQLException {
         return CompletableFuture.supplyAsync(() -> this.update(sqlStatement, psPreparer), this.threadPool);
+    }
+
+    /**
+     * Queries the database for results and returns a {@link QueryResults} instance.
+     *
+     * @param sqlStatement The SQL statement to execute
+     * @return The results of the query
+     * @throws UncheckedSQLException If a {@link SQLException} occurs
+     * @see QueryResults
+     */
+    public QueryResults query(@NotNull String sqlStatement) throws UncheckedSQLException {
+        return query(sqlStatement, null);
     }
 
     /**
@@ -72,6 +105,16 @@ public abstract class DatabaseClient {
         } catch (SQLException exception) {
             throw new UncheckedSQLException(exception);
         }
+    }
+
+    /**
+     * Does the same thing as {@link DatabaseClient#query(String)} except
+     * does everything asynchronously and returns a {@link CompletableFuture}.
+     *
+     * @see DatabaseClient#query(String)
+     */
+    public CompletableFuture<QueryResults> queryAsync(@NotNull String sqlStatement) {
+        return queryAsync(sqlStatement, null);
     }
 
     /**

--- a/src/main/java/pro/evanwright/saphira/DatabaseClient.java
+++ b/src/main/java/pro/evanwright/saphira/DatabaseClient.java
@@ -16,6 +16,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 public abstract class DatabaseClient {
+
     private final ExecutorService threadPool;
 
     protected DatabaseClient() {

--- a/src/main/java/pro/evanwright/saphira/DatabaseCredentials.java
+++ b/src/main/java/pro/evanwright/saphira/DatabaseCredentials.java
@@ -6,18 +6,34 @@ import org.jetbrains.annotations.NotNull;
  * Represents credentials to authenticate a {@link DatabaseClient} to the database.
  */
 public class DatabaseCredentials {
-    public final String host, database, username, password, port;
+    public final String poolName, host, database, username, password, port;
+    public final boolean optimizeHikari;
+
 
     public DatabaseCredentials(@NotNull String host, @NotNull String database, @NotNull String username, @NotNull String password) {
-        this(host, database, username, password, "3306");
+        this("Saphira Connection Pool", host, database, username, password, "3306", true);
     }
 
-    public DatabaseCredentials(@NotNull String host, @NotNull String database, @NotNull String username, @NotNull String password, @NotNull String port) {
+    public DatabaseCredentials(@NotNull String host, @NotNull String database, @NotNull String username, @NotNull String password, boolean optimizeHikari) {
+        this("Saphira Connection Pool", host, database, username, password, "3306", optimizeHikari);
+    }
+
+    public DatabaseCredentials(@NotNull String poolName, @NotNull String host, @NotNull String database, @NotNull String username, @NotNull String password) {
+        this(poolName, host, database, username, password, "3306", true);
+    }
+
+    public DatabaseCredentials(@NotNull String poolName, @NotNull String host, @NotNull String database, @NotNull String username, @NotNull String password, boolean optimizeHikari) {
+        this(poolName, host, database, username, password, "3306", optimizeHikari);
+    }
+
+    public DatabaseCredentials(@NotNull String poolName, @NotNull String host, @NotNull String database, @NotNull String username, @NotNull String password, @NotNull String port, boolean optimizeHikari) {
+        this.poolName = poolName;
         this.host = host;
         this.database = database;
         this.username = username;
         this.password = password;
         this.port = port;
+        this.optimizeHikari = optimizeHikari;
     }
 
     @Override

--- a/src/main/java/pro/evanwright/saphira/query/QueryResults.java
+++ b/src/main/java/pro/evanwright/saphira/query/QueryResults.java
@@ -239,6 +239,28 @@ public class QueryResults {
     }
 
     /**
+     * @see ResultSet#getLong(int)
+     */
+    public long getLong(int columnIndex) throws UncheckedSQLException {
+        try {
+            return this.resultSet.getLong(columnIndex);
+        } catch (SQLException exception) {
+            throw new UncheckedSQLException(exception);
+        }
+    }
+
+    /**
+     * @see ResultSet#getLong(String)
+     */
+    public long getLong(String columnLabel) throws UncheckedSQLException {
+        try {
+            return this.resultSet.getLong(columnLabel);
+        } catch (SQLException exception) {
+            throw new UncheckedSQLException(exception);
+        }
+    }
+
+    /**
      * @see java.sql.ResultSet#absolute(int)
      */
     public boolean absolute(int row) throws UncheckedSQLException {
@@ -390,5 +412,9 @@ public class QueryResults {
         } catch (SQLException exception) {
             throw new UncheckedSQLException(exception);
         }
+    }
+
+    public ResultSet getResultSet() {
+        return resultSet;
     }
 }


### PR DESCRIPTION
This PR adds:
- MariaDB support. (simply changing the connection url with mariadb instead of mysql if mariadb driver was found.)
- Adds an option to automatically optimize hikari configuration.
- Adds methods without an SQLConsumer. (simply executes the parent method with null consumer)
- Adds executeBatch and executeBatchAsync methods that are in the kotlin version but not in the java version.
- Adds QueryResults#getResultSet and QueryResults#getLong

Thanks for such an amazing and easy to use library!